### PR TITLE
Update Calendar.tsx

### DIFF
--- a/src/shared/ui/Calendar/Calendar.tsx
+++ b/src/shared/ui/Calendar/Calendar.tsx
@@ -35,9 +35,9 @@ const Calendar: React.FC = () => {
             {day}
           </div>
         ))}
-        {dayInfo.days.map((day) => (
+        {dayInfo.days.map((day, index) => (
           <div
-            key={day}
+            key={index}
             className={`${styles.cell} ${day === null ? styles.empty : ""}`}
           >
             {day || ""}


### PR DESCRIPTION
This fixes bugs and errors when filling days in the calendar.

Error in console: Warning: Encountered two children with the same key, 'null'.
Due to this error, after the change of month (next month, prev month), additional empty < div > appeared, due to which the calendar was incorrectly displayed